### PR TITLE
fix: update php-di adapter example

### DIFF
--- a/examples/php-di/Container.php
+++ b/examples/php-di/Container.php
@@ -12,7 +12,6 @@ use Your\Namespace\DI\Container as PHPDIContainer;
 
 class Container implements ContainerInterface {
 	protected $container;
-	protected $singletons = [];
 
 	/**
 	 * Container constructor.

--- a/examples/php-di/Container.php
+++ b/examples/php-di/Container.php
@@ -25,7 +25,7 @@ class Container implements ContainerInterface {
 	 * @inheritDoc
 	 */
 	public function bind( string $id, $implementation = null ) {
-		return $this->container->set( $id, $implementation );
+		$this->container->set( $id, $implementation );
 	}
 
 	/**
@@ -43,45 +43,9 @@ class Container implements ContainerInterface {
 	}
 
 	/**
-	 * Build an entry of the container by its name.
-	 *
-	 * This method behave like get() except resolves the entry again every time.
-	 * For example if the entry is a class then a new instance will be created each time.
-	 *
-	 * This method makes the container behave like a factory.
-	 *
-	 * @template T
-	 *
-	 * @param string|class-string<T> $name       Entry name or a class name.
-	 * @param array                  $parameters Optional parameters to use to build the entry. Use this to force
-	 *                                           specific parameters to specific values. Parameters not defined in this
-	 *                                           array will be resolved using the container.
-	 *
-	 * @return mixed|T
-	 * @throws InvalidArgumentException The name parameter must be of type string.
-	 * @throws DependencyException Error while resolving the entry.
-	 * @throws NotFoundException No entry found for the given name.
-	 */
-	public function make( string $id, array $parameters = [] ) {
-		if ( ! empty( $this->singletons[ $id ] ) ) {
-			return $this->container->get( $id );
-		}
-
-		return $this->container->make( $id, $parameters );
-	}
-
-	/**
 	 * @inheritDoc
 	 */
 	public function singleton( string $id, $implementation = null ) {
-		$this->singletons[ $id ] = true;
-		return $this->container->set( $id, $implementation );
-	}
-
-	/**
-	 * Defer all other calls to the container object.
-	 */
-	public function __call( $name, $args ) {
-		return $this->container->{$name}( ...$args );
+		$this->container->set( $id, $implementation );
 	}
 }


### PR DESCRIPTION
The existing PHP-DI adapter example does not work properly. The following fixes were tested with PHP-DI in the Validation library.