### PR TITLE
Add Generics + type bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 composer.lock
 composer.phar
 /vendor/

--- a/examples/di52/Container.php
+++ b/examples/di52/Container.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types=1 );
 
 namespace Your\Namespace;
 
@@ -10,6 +10,13 @@ use Your\Namespace\lucatume\DI52\Container as DI52Container;
 // If you are including lucatume\DI52 directly, then you'd want to do:
 // use lucatume\DI52\Container as DI52Container;
 
+/**
+ * @method mixed getVar(string $key, mixed|null $default = null)
+ * @method void register(string $serviceProviderClass, string ...$alias)
+ * @method self when(string $class)
+ * @method self needs(string $id)
+ * @method void give(mixed $implementation)
+ */
 class Container implements ContainerInterface {
 	/**
 	 * @var DI52Container

--- a/src/ContainerInterface.php
+++ b/src/ContainerInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types=1 );
 
 namespace StellarWP\ContainerContract;
 
@@ -6,25 +6,28 @@ namespace StellarWP\ContainerContract;
  * Describes the interface of a container that exposes methods to read its entries.
  */
 interface ContainerInterface {
+
 	/**
 	 * Binds an interface, a class or a string slug to an implementation.
 	 *
 	 * Existing implementations are replaced.
 	 *
-	 * @param string $id             Identifier of the entry to look for.
-	 * @param mixed  $implementation The implementation that should be bound to the alias(es); can be a
-	 *                               class name, an object or a closure.
+	 * @param string|class-string $id             Identifier of the entry to look for.
+	 * @param mixed               $implementation The implementation that should be bound to the alias(es); can be a
+	 *                                            class name, an object or a closure.
 	 *
-	 * @return mixed Entry.
+	 * @return void
 	 */
 	public function bind( string $id, $implementation = null );
 
 	/**
 	 * Finds an entry of the container by its identifier and returns it.
 	 *
-	 * @param string $id Identifier of the entry to look for.
+	 * @template T
 	 *
-	 * @return mixed Entry.
+	 * @param string|class-string<T> $id Identifier of the entry to look for.
+	 *
+	 * @return ($id is class-string<T> ? T : mixed) Entry.
 	 */
 	public function get( string $id );
 
@@ -35,7 +38,7 @@ interface ContainerInterface {
 	 * `has($id)` returning true does not mean that `get($id)` will not throw an exception.
 	 * It does however mean that `get($id)` will not throw a `NotFoundExceptionInterface`.
 	 *
-	 * @param string $id Identifier of the entry to look for.
+	 * @param string|class-string $id Identifier of the entry to look for.
 	 *
 	 * @return bool
 	 */
@@ -44,11 +47,12 @@ interface ContainerInterface {
 	/**
 	 * Binds an interface a class or a string slug to an implementation and will always return the same instance.
 	 *
-	 * @param string $id             Identifier of the entry to look for.
-	 * @param mixed  $implementation The implementation that should be bound to the alias(es); can be a
-	 *                               class name, an object or a closure.
+	 * @param string|class-string $id             Identifier of the entry to look for.
+	 * @param mixed               $implementation The implementation that should be bound to the alias(es); can be a
+	 *                                            class name, an object or a closure.
 	 *
 	 * @return void This method does not return any value.
 	 */
 	public function singleton( string $id, $implementation = null );
+
 }


### PR DESCRIPTION
### Fixed

- The return type for the `bind()` method for both di52/php-di is `void`, not `mixed`, so `ContainerInterface::bind()` now properly matches.

### Added

- Phpstan/Psalm Generics for for `get()` methods, most IDE's will auto-complete class instances based on this if you pass in a class-string, e.g `Some\Namespace\Some\ClassName::class` and if your project uses static analysis, it will catch errors.
- Union `class-string` params for relevant methods.
- The ContainerInterface now implements `declare( strict_types=1 );` as the composer.json says this project is `>=7.0.0`.
- `@method` DocBlocks for missing methods for the di52 example code (this will help some with IDE autocompletion).
- Git ignore PhpStorm's `.idea/` folder.

### Notes

- I suggested a `2.0.0` milestone release due to the `ContainerInterface::bind()` bugfix change, IDE's for existing projects likely forced a `return` statement on the concrete bind method, even though neither container returns anything for this method.