### PR TITLE
Add specific phpstan-return and update return

### DIFF
--- a/src/ContainerInterface.php
+++ b/src/ContainerInterface.php
@@ -27,7 +27,8 @@ interface ContainerInterface {
 	 *
 	 * @param string|class-string<T> $id Identifier of the entry to look for.
 	 *
-	 * @return ($id is class-string<T> ? T : mixed) Entry.
+	 * @return T|mixed
+	 * @phpstan-return ($id is class-string ? T : mixed)
 	 */
 	public function get( string $id );
 


### PR DESCRIPTION
This is a good work around to have PHPStorm understand autocompletion if using a fully-qualified class-string, until it supports conditional return types and this still passes PHPStan validation.

See [di52 3.3.5](https://github.com/lucatume/di52/releases/tag/3.3.5)